### PR TITLE
Return `null` rather than missing fields

### DIFF
--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -35,7 +35,7 @@ export interface Meeting {
   announcementType: string;
   streamUploadUrls: string[];
 
-  webex?: Webex;
+  webex: Webex | null;
 
   organizer: string;
 

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -32,9 +32,10 @@ export interface SessionOption extends NamedRecord {
 
 export interface SessionRole {
   classification: 'live' | 'ondemand';
-  exceptionList?: SecurityRule;
+  exceptionList: SecurityRule | null;
   targetPlatform: 'msteams' | 'jwt' | 't-systems' | 'youtube' | null;
-  securityRule?: SecurityRule;
+  securityRule: SecurityRule | null;
+  securityGroup: string;
   media: string;
   role: 'join' | 'watch';
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,10 +92,11 @@ export function normalizeSessionsResponse(response: ExternalVenueApiResponse): S
                   name: role.exception_list_name || '',
                   aadGroup: role.exception_list_aad_group || '',
                 }
-              : undefined,
+              : null,
           media: role.media,
           role: role.role,
           targetPlatform: role.target_platform,
+          securityGroup: role.security_group,
           securityRule:
             role.security_rule_id !== null
               ? {
@@ -103,7 +104,7 @@ export function normalizeSessionsResponse(response: ExternalVenueApiResponse): S
                   name: role.security_rule_name || '',
                   aadGroup: role.security_rule_aad_group || '',
                 }
-              : undefined,
+              : null,
         })),
       })),
     },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -150,7 +150,7 @@ export function normalizeMeetingsResponse(response: ExternalMeetingApiResponse):
           hostKey: v.webex_host_key,
           password: v.webex_password,
         }
-      : undefined,
+      : null,
 
     organizer: v.organizer,
 


### PR DESCRIPTION
**Changes**
- Change `securityRule` and `exceptionList` on role to return `null` if empty
- Change `Meeting.webex` to return `null` if empty
- Add `roles.securityGroup`